### PR TITLE
Update AGP to 3.2.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta04'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'com.google.gms:google-services:4.0.1'
         classpath "com.squareup.sqldelight:gradle-plugin:${versions.sqldelight}"


### PR DESCRIPTION
Makes the Android app easily buildable on the latest Android Studio version.