### PR TITLE
Remove release config

### DIFF
--- a/iosApp/.gitignore
+++ b/iosApp/.gitignore
@@ -1,0 +1,24 @@
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3

--- a/sessionize/app/build.gradle
+++ b/sessionize/app/build.gradle
@@ -3,16 +3,6 @@ apply plugin: 'kotlin-multiplatform'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.fabric'
 
-Properties properties = new Properties()
-try {
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-}
-catch(Exception e) {
-
-}
-
-def releasePassword = properties.getProperty('releasePassword')
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -31,23 +21,6 @@ android {
     }
     lintOptions {
         abortOnError false
-    }
-
-    signingConfigs {
-        release {
-            storeFile file("release.jks")
-            keyAlias "key0"
-            storePassword "$releasePassword"
-            keyPassword "$releasePassword"
-        }
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
-        }
     }
 }
 


### PR DESCRIPTION
This change deletes release signing configs from the app build.gradle. This will make it easier to use this as an example app.