### PR TITLE
Add a body to the RSVP call

### DIFF
--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/BaseModel.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/BaseModel.kt
@@ -1,5 +1,6 @@
 package co.touchlab.sessionize
 
+import co.touchlab.sessionize.platform.logException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -14,7 +15,9 @@ open class BaseModel(
         showError(throwable)
     }
 
-    open fun showError(t: Throwable) {}
+    open fun showError(t: Throwable) {
+        logException(t)
+    }
 
     override val coroutineContext: CoroutineContext
         get() = mainContext + job + exceptionHandler

--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/SessionizeApiImpl.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/SessionizeApiImpl.kt
@@ -45,6 +45,7 @@ object SessionizeApiImpl : SessionizeApi {
     override suspend fun recordRsvp(methodName: String, sessionId: String): Boolean = client.request<HttpResponse> {
         droidcon("/dataTest/$methodName/$sessionId/${userUuid()}")
         method = HttpMethod.Post
+        body = ""
     }.use {
         it.status.isSuccess()
     }


### PR DESCRIPTION
A body is required for POST so this was always failing. added a print statement to our coroutine error handler so that we get logs for this kind of thing at least