### PR TITLE
Remove strong references to SessionizeApiImpl

### DIFF
--- a/iosApp/iosApp/app/AppDelegate.swift
+++ b/iosApp/iosApp/app/AppDelegate.swift
@@ -37,7 +37,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                 coroutineDispatcher: UI(),
                                                 settings: FunctionsKt.defaultSettings(),
                                                 concurrent: MainConcurrent(),
-                                                sessionizeApi: SessionizeApiImpl(),
                                                 analyticsApi: FunctionsKt.createAnalyticsApiImpl(analyticsCallback: analyticsCallback),
                                                 notificationsApi: NotificationsApiImpl(),
                                                 timeZone: timeZone)

--- a/sessionize/app/src/main/java/co/touchlab/sessionize/MainApp.kt
+++ b/sessionize/app/src/main/java/co/touchlab/sessionize/MainApp.kt
@@ -23,7 +23,6 @@ class MainApp : Application() {
                 Dispatchers.Main,
                 AndroidSettings.Factory(this).create("DROIDCON_SETTINGS"),
                 MainConcurrent,
-                SessionizeApiImpl,
                 AnalyticsApiImpl(FirebaseAnalytics.getInstance(this)),
                 NotificationsApiImpl(),
                 BuildConfig.TIME_ZONE

--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/EventModel.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/EventModel.kt
@@ -3,6 +3,7 @@ package co.touchlab.sessionize
 import co.touchlab.droidcon.db.MySessions
 import co.touchlab.droidcon.db.Session
 import co.touchlab.droidcon.db.UserAccount
+import co.touchlab.sessionize.api.SessionizeApiImpl
 import co.touchlab.sessionize.db.SessionizeDbHelper.sessionQueries
 import co.touchlab.sessionize.db.SessionizeDbHelper.userAccountQueries
 import co.touchlab.sessionize.db.room
@@ -53,7 +54,7 @@ class EventModel(val sessionId: String) : BaseQueryModelView<Session, SessionInf
         NotificationsModel.recreateReminderNotifications()
         NotificationsModel.recreateFeedbackNotifications()
         if (rsvp) {
-            ServiceRegistry.sessionizeApi.recordRsvp(methodName, localSessionId)
+            SessionizeApiImpl().recordRsvp(methodName, localSessionId)
 
             sendAnalytics(localSessionId, rsvp)
         }

--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/ServiceRegistry.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/ServiceRegistry.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KProperty
 
 object ServiceRegistry {
-    var sessionizeApi:SessionizeApi by FrozenDelegate()
+    //var sessionizeApi:SessionizeApi by FrozenDelegate()
     var analyticsApi: AnalyticsApi by FrozenDelegate()
     var notificationsApi:NotificationsApi by FrozenDelegate()
     var dbDriver: SqlDriver by FrozenDelegate()
@@ -25,13 +25,12 @@ object ServiceRegistry {
     var clLogCallback: ((s: String) -> Unit) by FrozenDelegate()
 
     fun initServiceRegistry(sqlDriver: SqlDriver, coroutineDispatcher: CoroutineDispatcher, settings: Settings,
-                            concurrent: Concurrent, sessionizeApi: SessionizeApi, analyticsApi: AnalyticsApi,
+                            concurrent: Concurrent, analyticsApi: AnalyticsApi,
                             notificationsApi: NotificationsApi, timeZone: String) {
         ServiceRegistry.dbDriver = sqlDriver
         ServiceRegistry.coroutinesDispatcher = coroutineDispatcher
         ServiceRegistry.appSettings = settings
         ServiceRegistry.concurrent = concurrent
-        ServiceRegistry.sessionizeApi = sessionizeApi
         ServiceRegistry.analyticsApi = analyticsApi
         ServiceRegistry.notificationsApi = notificationsApi
         ServiceRegistry.appSettings = settings

--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/NetworkRepo.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/NetworkRepo.kt
@@ -19,7 +19,7 @@ import kotlin.native.concurrent.ThreadLocal
 object NetworkRepo {
     fun dataCalls() = CoroutineScope(ServiceRegistry.coroutinesDispatcher).launch {
         try {
-            val api = ServiceRegistry.sessionizeApi
+            val api = SessionizeApiImpl()// ServiceRegistry.sessionizeApi
             val networkSpeakerJson = api.getSpeakersJson()
             val networkSessionJson = api.getSessionsJson()
             val networkSponsorJson = api.getSponsorJson()

--- a/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/SessionizeApiImpl.kt
+++ b/sessionize/lib/src/commonMain/kotlin/co/touchlab/sessionize/api/SessionizeApiImpl.kt
@@ -5,7 +5,6 @@ import co.touchlab.sessionize.SettingsKeys
 import co.touchlab.sessionize.jsondata.Days
 import co.touchlab.sessionize.jsondata.Session
 import co.touchlab.sessionize.platform.createUuid
-import co.touchlab.stately.freeze
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
@@ -20,11 +19,11 @@ import kotlinx.serialization.list
 import kotlin.native.concurrent.ThreadLocal
 
 @ThreadLocal
-object SessionizeApiImpl : SessionizeApi {
+class SessionizeApiImpl : SessionizeApi {
     private val INSTANCE_ID = "eh8k1018"
     private val client = HttpClient {
         install(ExpectSuccess)
-    }.freeze()
+    }
 
     override suspend fun getSpeakersJson(): String = client.get<String> {
         sessionize("/api/v2/$INSTANCE_ID/view/speakers")


### PR DESCRIPTION
This issue was actually mentioned in the ktor github page:
https://github.com/ktorio/ktor/issues/887

In Short:
"Don't freeze your HttpClient, it doesn't work.

That means don't put it inside an object for example, or inside an instance of a class stored inside an object, etc"