### PR TITLE
Fix the session details status message

### DIFF
--- a/android/src/main/java/co/touchlab/droidcon/android/viewModel/sessions/SessionDetailViewModel.kt
+++ b/android/src/main/java/co/touchlab/droidcon/android/viewModel/sessions/SessionDetailViewModel.kt
@@ -83,6 +83,7 @@ class SessionDetailViewModel: ViewModel(), KoinComponent {
             when {
                 it.session.endsAt < now -> R.string.schedule_session_detail_status_past
                 it.session.startsAt > now -> R.string.schedule_session_detail_status_future
+                it.session.startsAt <= now && now <= it.session.endsAt -> R.string.schedule_session_detail_status_in_progress
                 it.isInConflict -> R.string.schedule_session_detail_status_conflict
                 else -> null
             }


### PR DESCRIPTION
This PR fixes three bugs that I encountered on the session details screen on Android -

Given a session that started at 9:50am and my phone time set to 9:55am, in the same timezone as the conference.
* when I view the session details screen 
**ER:** The status message should tell me that the session is happening now
**AR:** The app tells me that the session hasnt yet started

* when I view the speaker bio and return to session details
**ER:** I should see a status message
**AR:** The session status message is blank, and the (i) icon is still visible

* when I cause a config change on the session details screen
**ER:** I should see a status message
**AR:** The session status message is blank, and the (i) icon is still visible
