### PR TITLE
Schedule alarms in the device's own timezone

### DIFF
--- a/shared/src/commonMain/kotlin/co/touchlab/droidcon/Koin.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/droidcon/Koin.kt
@@ -195,6 +195,7 @@ private val coreModule = module {
             settings = get(),
             json = get(),
             localizedStringFactory = get(),
+            dateTimeService = get()
         )
     }
     single<ServerApi> {

--- a/shared/src/commonMain/kotlin/co/touchlab/droidcon/domain/service/DateTimeService.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/droidcon/domain/service/DateTimeService.kt
@@ -14,6 +14,8 @@ interface DateTimeService {
 
     fun Instant.toDeviceDateTime(): LocalDateTime
 
+    fun Instant.fromConferenceToDeviceInstant(): Instant
+
     fun LocalDateTime.fromConferenceDateTime(): Instant
 
     fun LocalDateTime.fromDeviceDateTime(): Instant
@@ -25,6 +27,10 @@ fun Instant.toConferenceDateTime(dateTimeService: DateTimeService): LocalDateTim
 
 fun Instant.toDeviceDateTime(dateTimeService: DateTimeService): LocalDateTime = with(dateTimeService) {
     toDeviceDateTime()
+}
+
+fun Instant.fromConferenceToDeviceInstant(dateTimeService: DateTimeService): Instant = with(dateTimeService) {
+    fromConferenceToDeviceInstant()
 }
 
 fun LocalDateTime.fromConferenceDateTime(dateTimeService: DateTimeService): Instant = with(dateTimeService) {

--- a/shared/src/commonMain/kotlin/co/touchlab/droidcon/domain/service/impl/DefaultDateTimeService.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/droidcon/domain/service/impl/DefaultDateTimeService.kt
@@ -28,6 +28,10 @@ class DefaultDateTimeService(
         return toLocalDateTime(deviceTimeZone)
     }
 
+    override fun Instant.fromConferenceToDeviceInstant(): Instant {
+        return toConferenceDateTime().toInstant(deviceTimeZone)
+    }
+
     override fun LocalDateTime.fromConferenceDateTime(): Instant {
         return toInstant(conferenceTimeZone)
     }


### PR DESCRIPTION
Given a session that started at 11:10am that lasts 30 minutes and my device was in Central European Time (2 hours ahead of GMT).

Before this change, alarm scheduling was scheduling for 11:10 UTC which the system saw as being 1:10pm and the alarms were therefore set for
```
Alarm time: Wed Oct 20 13:00:00 GMT+02:00 2021
Alarm time: Wed Oct 20 13:40:00 GMT+02:00 2021
```

This change pushes the start and end `Instant` into *device time* before scheduling so that the notifications appear when expected.