### PR TITLE
Fix conference selector not showing selected conference when first opened

### DIFF
--- a/shared/src/commonMain/kotlin/co/touchlab/droidcon/application/repository/impl/DefaultSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/droidcon/application/repository/impl/DefaultSettingsRepository.kt
@@ -40,7 +40,17 @@ class DefaultSettingsRepository(private val observableSettings: ObservableSettin
             isRemindersEnabled = isRemindersEnabled,
             useComposeForIos = useComposeForIos,
         ),
-    )
+    ).also { flow ->
+        observableSettings.addBooleanListener(SETTINGS_FEEDBACK_ENABLED_KEY) { newValue ->
+            flow.value = flow.value.copy(isFeedbackEnabled = newValue)
+        }
+        observableSettings.addBooleanListener(SETTINGS_REMINDERS_ENABLED_KEY) { newValue ->
+            flow.value = flow.value.copy(isRemindersEnabled = newValue)
+        }
+        observableSettings.addBooleanListener(SETTINGS_USE_COMPOSE_FOR_IOS_KEY) { newValue ->
+            flow.value = flow.value.copy(useComposeForIos = newValue)
+        }
+    }
 
     override suspend fun set(settings: Settings) {
         isFeedbackEnabled = settings.isFeedbackEnabled


### PR DESCRIPTION
When opening the conference selector in settings, the currently selected conference was not shown as selected in the dropdown menu. This was because the selected conference was only being loaded through a Flow, which might take a moment to emit its first value.

This PR fixes the issue by:
1. Immediately loading the selected conference using `getSelected()` when the view model is attached
2. Then setting up the Flow observers to keep the values updated
3. This ensures that when the dropdown menu is opened, the selected conference is already available and the radio button will be correctly selected

The fix ensures that users can see which conference is currently selected as soon as they open the conference selector dropdown.